### PR TITLE
Add project and app scaffolding management commands

### DIFF
--- a/adjango/management/commands/astartproject.py
+++ b/adjango/management/commands/astartproject.py
@@ -1,0 +1,81 @@
+# management/commands/astartproject.py
+"""Create new Django project with config package and apps/core structure."""
+
+from pathlib import Path
+
+from django.core.management import BaseCommand, CommandError, call_command
+
+
+class Command(BaseCommand):
+    """Custom startproject command creating config package and default core app."""
+
+    help = "Create a new project with inner 'config' package and default 'core' app."  # noqa: A003
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'name',
+            help='Name of the project (outer directory).'
+        )
+        parser.add_argument(
+            'directory',
+            nargs='?',
+            default=None,
+            help='Optional target directory.'
+        )
+
+    def handle(self, *args, **options):
+        project_name = options['name']
+        directory = options['directory']
+
+        target_dir = Path(directory or project_name).resolve()
+        if target_dir.exists():
+            raise CommandError(f"Directory '{target_dir}' already exists")
+
+        target_dir.mkdir(parents=True)
+
+        # Use Django's startproject to create base structure with inner package 'config'.
+        call_command('startproject', 'config', str(target_dir))
+
+        apps_dir = target_dir / 'apps'
+        core_dir = apps_dir / 'core'
+        roads_dir = core_dir / 'roads'
+
+        # Create apps/core/roads structure
+        roads_dir.mkdir(parents=True)
+        (apps_dir / '__init__.py').write_text('')
+        (core_dir / '__init__.py').write_text('')
+        (roads_dir / '__init__.py').write_text('')
+        (roads_dir / 'root.py').write_text(
+            'from django.urls import path\n\nurlpatterns = []\n'
+        )
+
+        # Adjust settings
+        settings_path = target_dir / 'config' / 'settings.py'
+        content = settings_path.read_text().splitlines()
+
+        # Insert apps.core into INSTALLED_APPS
+        for i, line in enumerate(content):
+            if line.strip().startswith('INSTALLED_APPS') and line.strip().endswith('['):
+                content.insert(i + 1, "    'apps.core',")
+                break
+        else:  # pragma: no cover - default startproject always has INSTALLED_APPS
+            raise CommandError('INSTALLED_APPS not found in settings.py')
+
+        # Set ROOT_URLCONF to core roads
+        replaced = False
+        for i, line in enumerate(content):
+            if line.strip().startswith('ROOT_URLCONF'):
+                content[i] = "ROOT_URLCONF = 'apps.core.roads.root'"
+                replaced = True
+                break
+        if not replaced:
+            content.append("ROOT_URLCONF = 'apps.core.roads.root'")
+
+        settings_path.write_text('\n'.join(content) + '\n')
+
+        # Remove default urls.py as routes are stored in core roads
+        default_urls = target_dir / 'config' / 'urls.py'
+        if default_urls.exists():
+            default_urls.unlink()
+
+        self.stdout.write(self.style.SUCCESS(f"Project created at {target_dir}"))

--- a/adjango/management/commands/astartup.py
+++ b/adjango/management/commands/astartup.py
@@ -1,0 +1,62 @@
+# management/commands/astartup.py
+"""Create an application inside the apps directory with default structure."""
+
+from pathlib import Path
+
+from django.core.management import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    """Create app skeleton in ``apps`` and register it in settings."""  # noqa: A003
+
+    help = "Create app inside apps folder with pre-defined structure."  # noqa: A003
+
+    def add_arguments(self, parser):
+        parser.add_argument('name', help='Application name')
+
+    def handle(self, *args, **options):
+        app_name = options['name']
+        base_dir = Path.cwd()
+        apps_dir = base_dir / 'apps'
+        if not apps_dir.exists():
+            raise CommandError('apps directory not found')
+
+        app_dir = apps_dir / app_name
+        if app_dir.exists():
+            raise CommandError(f"App '{app_name}' already exists")
+
+        # Define required subdirectories and file names
+        directories = {
+            'controllers': 'base.py',
+            'admin': 'base.py',
+            'exceptions': 'base.py',
+            'models': 'base.py',
+            'roads': 'api.py',
+            'serializers': 'base.py',
+            'services': 'base.py',
+            'tests': 'base.py',
+        }
+
+        for folder, filename in directories.items():
+            path = app_dir / folder
+            path.mkdir(parents=True, exist_ok=True)
+            (path / '__init__.py').write_text('')
+            (path / filename).write_text('')
+
+        (app_dir / '__init__.py').write_text('')
+
+        # Update settings.py to include the new app
+        settings_path = base_dir / 'config' / 'settings.py'
+        content = settings_path.read_text().splitlines()
+        inserted = False
+        for i, line in enumerate(content):
+            if line.strip().startswith('INSTALLED_APPS') and line.strip().endswith('['):
+                content.insert(i + 1, f"    'apps.{app_name}',")
+                inserted = True
+                break
+        if not inserted:
+            raise CommandError('INSTALLED_APPS not found in settings.py')
+
+        settings_path.write_text('\n'.join(content) + '\n')
+
+        self.stdout.write(self.style.SUCCESS(f"App '{app_name}' created"))

--- a/tests/test_astart_commands.py
+++ b/tests/test_astart_commands.py
@@ -1,0 +1,43 @@
+from django.core.management import call_command
+
+from adjango.management.commands.astartproject import Command as StartProjectCommand
+from adjango.management.commands.astartup import Command as StartupCommand
+
+
+def test_astartproject_creates_structure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    call_command(StartProjectCommand(), 'sample')
+
+    project_dir = tmp_path / 'sample'
+    assert (project_dir / 'manage.py').exists()
+    settings_path = project_dir / 'config' / 'settings.py'
+    content = settings_path.read_text()
+    assert "'apps.core'" in content
+    assert "ROOT_URLCONF = 'apps.core.roads.root'" in content
+    assert (project_dir / 'apps' / 'core' / 'roads' / 'root.py').exists()
+
+
+def test_astartup_creates_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    call_command(StartProjectCommand(), 'sample')
+    project_dir = tmp_path / 'sample'
+    monkeypatch.chdir(project_dir)
+
+    call_command(StartupCommand(), 'blog')
+
+    blog_dir = project_dir / 'apps' / 'blog'
+    expected = {
+        'controllers/base.py',
+        'admin/base.py',
+        'exceptions/base.py',
+        'models/base.py',
+        'roads/api.py',
+        'serializers/base.py',
+        'services/base.py',
+        'tests/base.py',
+    }
+    for path in expected:
+        assert (blog_dir / path).exists()
+
+    settings_path = project_dir / 'config' / 'settings.py'
+    assert "'apps.blog'" in settings_path.read_text()


### PR DESCRIPTION
## Summary
- add `astartproject` command that bootstraps a Django project with `config` package and default `core` app
- add `astartup` command to generate structured apps and register them in settings
- test custom project and app scaffolding commands

## Testing
- `pytest tests/test_astart_commands.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a133fbf1208330bf92d53ae863007f