### PR TITLE
feat: generic model services typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,19 @@ A simple example and everything is immediately clear...
 ```python
 from adjango.fields import AManyToManyField
 from adjango.managers.base import AManager
-from adjango.services.object.base import ABaseModelObjectService
-from adjango.models import AModel
+from adjango.services.base import ABaseService
+from adjango.models import AModel, AAbstractUser
 from adjango.polymorphic_models import APolymorphicModel
 
 
-class User(AbstractUser, ABaseModelObjectService):
+class UserService(ABaseService["User"]):
+  def __init__(self, obj: "User") -> None:
+    super().__init__(obj)
+
+
+class User(AAbstractUser[UserService]):
+  service_class = UserService
   objects = AManager()
-
-
-# Its equal with...
-class User(AbstractUser, AModel): pass
 
 
 class Product(APolymorphicModel):

--- a/adjango/models/base.py
+++ b/adjango/models/base.py
@@ -1,20 +1,23 @@
 # models/base.py
 from django.contrib.auth.models import AbstractUser
 from django.db.models import Model
+from typing import Generic, TypeVar
 
 from adjango.managers.base import AManager, AUserManager
 from adjango.services.base import ABaseService
 from adjango.services.object.base import ABaseModelObjectService
 
+ServiceT = TypeVar('ServiceT', bound=ABaseService)
 
-class AModel(Model, ABaseModelObjectService[ABaseService]):
+
+class AModel(Model, ABaseModelObjectService[ServiceT], Generic[ServiceT]):
     objects = AManager()
 
     class Meta:
         abstract = True
 
 
-class AAbstractUser(AbstractUser, AModel):
+class AAbstractUser(AbstractUser, AModel[ServiceT], Generic[ServiceT]):
     objects = AUserManager()
 
     class Meta:

--- a/adjango/services/base.py
+++ b/adjango/services/base.py
@@ -1,12 +1,14 @@
 from abc import ABC, abstractmethod
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
     from adjango.models import AModel
 
+ModelT = TypeVar('ModelT', bound='AModel[Any]')
 
-class ABaseService(ABC):
+
+class ABaseService(Generic[ModelT], ABC):
     @abstractmethod
-    def __init__(self, obj: 'AModel') -> None:
-        self.obj: 'AModel' = obj
+    def __init__(self, obj: ModelT) -> None:
+        self.obj: ModelT = obj

--- a/adjango/services/object/base.py
+++ b/adjango/services/object/base.py
@@ -6,7 +6,7 @@ from django.db.models import Model
 from adjango.services.base import ABaseService
 from adjango.utils.funcs import arelated
 
-ServiceT = TypeVar('ServiceT', bound=ABaseService)
+ServiceT = TypeVar('ServiceT', bound=ABaseService[Any])
 
 
 class ABaseModelObjectService(Generic[ServiceT]):

--- a/tests/project/app/models.py
+++ b/tests/project/app/models.py
@@ -7,10 +7,18 @@ from django.db.models import (
 
 from adjango.fields import AManyToManyField
 from adjango.models.base import AModel, AAbstractUser
+from adjango.services.base import ABaseService
 from adjango.models.polymorphic import APolymorphicModel
 
 
-class User(AAbstractUser):
+
+class UserService(ABaseService["User"]):
+    def __init__(self, obj: "User") -> None:
+        super().__init__(obj)
+
+
+class User(AAbstractUser[UserService]):
+    service_class = UserService
     phone = CharField(max_length=20, unique=True)
 
 


### PR DESCRIPTION
## Summary
- make `AModel` and `AAbstractUser` generic to propagate concrete service types
- parameterize `ABaseService` and related helpers with model generics
- update `ABaseModelObjectService` to respect typed service classes
- illustrate service typing with docs and test model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a14d93780483309d17fac01ecd8304