### PR TITLE
Improve typing for async manager and queryset helpers

### DIFF
--- a/adjango/managers/base.py
+++ b/adjango/managers/base.py
@@ -1,7 +1,7 @@
 # managers/base.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from asgiref.sync import sync_to_async
 from django.contrib.auth.models import UserManager
@@ -17,7 +17,40 @@ _M = TypeVar("_M", bound="Model")
 
 
 class AManager(Manager.from_queryset(AQuerySet), Generic[_M]):  # type: ignore
-    pass
+    """Асинхронный менеджер с типизированными методами."""
+
+    def get_queryset(self) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().get_queryset())
+
+    async def aall(self) -> list[_M]:
+        return await self.get_queryset().aall()
+
+    async def afilter(self, *args, **kwargs) -> list[_M]:
+        return await self.get_queryset().afilter(*args, **kwargs)
+
+    async def aget(self, *args, **kwargs) -> _M:
+        return await self.get_queryset().aget(*args, **kwargs)
+
+    async def afirst(self) -> _M | None:
+        return await self.get_queryset().afirst()
+
+    async def alast(self) -> _M | None:
+        return await self.get_queryset().alast()
+
+    async def acreate(self, **kwargs) -> _M:
+        return await self.get_queryset().acreate(**kwargs)
+
+    async def aget_or_create(self, defaults=None, **kwargs) -> tuple[_M, bool]:
+        return await self.get_queryset().aget_or_create(defaults=defaults, **kwargs)
+
+    async def aupdate_or_create(self, defaults=None, **kwargs) -> tuple[_M, bool]:
+        return await self.get_queryset().aupdate_or_create(defaults=defaults, **kwargs)
+
+    async def acount(self) -> int:
+        return await self.get_queryset().acount()
+
+    async def aexists(self) -> bool:
+        return await self.get_queryset().aexists()
 
 
 class AUserManager(UserManager, AManager[_M]):

--- a/adjango/querysets/base.py
+++ b/adjango/querysets/base.py
@@ -1,7 +1,7 @@
 # querysets/base.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, Type, TypeVar, cast
 
 from asgiref.sync import sync_to_async
 from django.db.models import QuerySet
@@ -74,18 +74,18 @@ class AQuerySet(QuerySet[_M], Generic[_M]):
         """Асинхронный exists - проверяет существование объектов."""
         return await sync_to_async(self.exists)()
 
-    def filter(self, *args, **kwargs) -> Union["AQuerySet[_M]", "QuerySet"]:
+    def filter(self, *args, **kwargs) -> "AQuerySet[_M]":
         """Переопределяем filter чтобы он возвращал правильный тип QuerySet."""
-        return super().filter(*args, **kwargs)
+        return cast("AQuerySet[_M]", super().filter(*args, **kwargs))
 
-    def exclude(self, *args, **kwargs) -> Union["AQuerySet[_M]", "QuerySet"]:
+    def exclude(self, *args, **kwargs) -> "AQuerySet[_M]":
         """Переопределяем exclude чтобы он возвращал правильный тип QuerySet."""
-        return super().exclude(*args, **kwargs)
+        return cast("AQuerySet[_M]", super().exclude(*args, **kwargs))
 
-    def prefetch_related(self, *lookups) -> Union["AQuerySet[_M]", "QuerySet"]:
+    def prefetch_related(self, *lookups) -> "AQuerySet[_M]":
         """Переопределяем prefetch_related чтобы он возвращал правильный тип QuerySet."""
-        return super().prefetch_related(*lookups)
+        return cast("AQuerySet[_M]", super().prefetch_related(*lookups))
 
-    def select_related(self, *fields) -> Union["AQuerySet[_M]", "QuerySet"]:
+    def select_related(self, *fields) -> "AQuerySet[_M]":
         """Переопределяем select_related чтобы он возвращал правильный тип QuerySet."""
-        return super().select_related(*fields)
+        return cast("AQuerySet[_M]", super().select_related(*fields))

--- a/adjango/utils/funcs.py
+++ b/adjango/utils/funcs.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Optional, Type
+from typing import Any, Iterable, Optional, Type, TypeVar
 from urllib.parse import urlparse
 
 from asgiref.sync import sync_to_async
@@ -15,13 +15,15 @@ from django.shortcuts import resolve_url
 
 from adjango.utils.base import download_file_to_temp
 
+_M = TypeVar("_M", bound=Model)
+
 
 def getorn(
-    queryset: QuerySet,
+    queryset: QuerySet[_M],
     exception: Type[Exception] | None = None,
     *args: Any,
     **kwargs: Any,
-) -> Any:
+) -> _M | None:
     """
     Gets single object from given QuerySet matching passed parameters.
 
@@ -47,11 +49,11 @@ def getorn(
 
 
 async def agetorn(
-    queryset: QuerySet,
+    queryset: QuerySet[_M],
     exception: Type[Exception] | None = None,
     *args: Any,
     **kwargs: Any,
-) -> Any:
+) -> _M | None:
     """
     Async gets single object from given QuerySet matching passed parameters.
 
@@ -76,7 +78,7 @@ async def agetorn(
     return None
 
 
-async def arelated(obj: Model, field: str) -> Any:
+async def arelated(obj: Model, field: str) -> Model:
     """
     Async gets related object from model by specified related field name.
 
@@ -96,7 +98,7 @@ async def arelated(obj: Model, field: str) -> Any:
         return await sync_to_async(getattr)(obj, field)
 
 
-async def aset(related_manager, data, *args, **kwargs) -> None:
+async def aset(related_manager: Manager[_M] | QuerySet[_M], data: Iterable[_M], *args, **kwargs) -> None:
     """
     Set related objects for ManyToMany field asynchronously.
 
@@ -107,7 +109,7 @@ async def aset(related_manager, data, *args, **kwargs) -> None:
     await sync_to_async(related_manager.set)(data, *args, **kwargs)
 
 
-async def aadd(objects: Manager | QuerySet, data: Any, *args: Any, **kwargs: Any) -> None:
+async def aadd(objects: Manager[_M] | QuerySet[_M], data: _M, *args: Any, **kwargs: Any) -> None:
     """
     Async adds object or data to ManyToMany field via add() method.
 
@@ -123,7 +125,7 @@ async def aadd(objects: Manager | QuerySet, data: Any, *args: Any, **kwargs: Any
     return await sync_to_async(objects.add)(data, *args, **kwargs)
 
 
-async def aall(objects: Manager | QuerySet) -> list:
+async def aall(objects: Manager[_M] | QuerySet[_M]) -> list[_M]:
     """
     Async returns all objects managed by manager.
 
@@ -136,7 +138,7 @@ async def aall(objects: Manager | QuerySet) -> list:
     return await sync_to_async(lambda: list(objects.all()))()
 
 
-async def afilter(queryset: QuerySet, *args: Any, **kwargs: Any) -> list:
+async def afilter(queryset: QuerySet[_M], *args: Any, **kwargs: Any) -> list[_M]:
     """
     Async filters objects from QuerySet by given parameters.
 


### PR DESCRIPTION
## Summary
- add typed async methods to `AManager`
- keep `AQuerySet` chaining methods typed
- use generics in async utility helpers for model-aware return types

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38c61602c833093dd3dadf33e3ab3