### PR TITLE
Improve async manager typing and ManyToMany helpers

### DIFF
--- a/adjango/fields.py
+++ b/adjango/fields.py
@@ -9,11 +9,14 @@ from adjango.descriptors import AManyToManyDescriptor
 
 if TYPE_CHECKING:
     from django.db.models import Model
+    from adjango.managers.base import AManager
 
 _RM = TypeVar("_RM", bound="Model")
 
 
 class AManyToManyField(ManyToManyField):
+    if TYPE_CHECKING:
+        def __get__(self, instance: "Model | None", owner: type | None = None) -> AManager[_RM]: ...
     def __class_getitem__(cls, item):
         """Поддержка для Generic типизации AManyToManyField[Model]."""
         # Сохраняем информацию о типе для дальнейшего использования

--- a/adjango/managers/base.py
+++ b/adjango/managers/base.py
@@ -1,7 +1,7 @@
 # managers/base.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Iterable, TypeVar, cast
 
 from asgiref.sync import sync_to_async
 from django.contrib.auth.models import UserManager
@@ -51,6 +51,27 @@ class AManager(Manager.from_queryset(AQuerySet), Generic[_M]):  # type: ignore
 
     async def aexists(self) -> bool:
         return await self.get_queryset().aexists()
+
+    async def aset(self, data: Iterable[_M], *args: Any, **kwargs: Any) -> None:
+        """Асинхронная версия set() для ManyToMany полей."""
+        await self.get_queryset().aset(data, *args, **kwargs)
+
+    async def aadd(self, data: _M, *args: Any, **kwargs: Any) -> None:
+        """Асинхронная версия add() для ManyToMany полей."""
+        await self.get_queryset().aadd(data, *args, **kwargs)
+
+    # Typed queryset-returning methods to preserve chaining types
+    def filter(self, *args: Any, **kwargs: Any) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().filter(*args, **kwargs))
+
+    def exclude(self, *args: Any, **kwargs: Any) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().exclude(*args, **kwargs))
+
+    def prefetch_related(self, *lookups: Any) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().prefetch_related(*lookups))
+
+    def select_related(self, *fields: Any) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().select_related(*fields))
 
 
 class AUserManager(UserManager, AManager[_M]):

--- a/adjango/managers/polymorphic.py
+++ b/adjango/managers/polymorphic.py
@@ -1,7 +1,7 @@
 # managers/polymorphic.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Iterable, TypeVar, cast
 
 if TYPE_CHECKING:
     from django.db.models import Model
@@ -17,7 +17,56 @@ try:
     class APolymorphicManager(PolymorphicManager.from_queryset(APolymorphicQuerySet), Generic[_M]):  # type: ignore
         """Enhanced polymorphic manager with proper type hints."""
 
-        pass
+        def get_queryset(self) -> APolymorphicQuerySet[_M]:  # type: ignore[override]
+            return cast(APolymorphicQuerySet[_M], super().get_queryset())
+
+        async def aall(self) -> list[_M]:
+            return await self.get_queryset().aall()
+
+        async def afilter(self, *args: Any, **kwargs: Any) -> list[_M]:
+            return await self.get_queryset().afilter(*args, **kwargs)
+
+        async def aget(self, *args: Any, **kwargs: Any) -> _M:
+            return await self.get_queryset().aget(*args, **kwargs)
+
+        async def afirst(self) -> _M | None:
+            return await self.get_queryset().afirst()
+
+        async def alast(self) -> _M | None:
+            return await self.get_queryset().alast()
+
+        async def acreate(self, **kwargs: Any) -> _M:
+            return await self.get_queryset().acreate(**kwargs)
+
+        async def aget_or_create(self, defaults=None, **kwargs: Any) -> tuple[_M, bool]:
+            return await self.get_queryset().aget_or_create(defaults=defaults, **kwargs)
+
+        async def aupdate_or_create(self, defaults=None, **kwargs: Any) -> tuple[_M, bool]:
+            return await self.get_queryset().aupdate_or_create(defaults=defaults, **kwargs)
+
+        async def acount(self) -> int:
+            return await self.get_queryset().acount()
+
+        async def aexists(self) -> bool:
+            return await self.get_queryset().aexists()
+
+        async def aset(self, data: Iterable[_M], *args: Any, **kwargs: Any) -> None:
+            await self.get_queryset().aset(data, *args, **kwargs)
+
+        async def aadd(self, data: _M, *args: Any, **kwargs: Any) -> None:
+            await self.get_queryset().aadd(data, *args, **kwargs)
+
+        def filter(self, *args: Any, **kwargs: Any) -> APolymorphicQuerySet[_M]:  # type: ignore[override]
+            return cast(APolymorphicQuerySet[_M], super().filter(*args, **kwargs))
+
+        def exclude(self, *args: Any, **kwargs: Any) -> APolymorphicQuerySet[_M]:  # type: ignore[override]
+            return cast(APolymorphicQuerySet[_M], super().exclude(*args, **kwargs))
+
+        def prefetch_related(self, *lookups: Any) -> APolymorphicQuerySet[_M]:  # type: ignore[override]
+            return cast(APolymorphicQuerySet[_M], super().prefetch_related(*lookups))
+
+        def select_related(self, *fields: Any) -> APolymorphicQuerySet[_M]:  # type: ignore[override]
+            return cast(APolymorphicQuerySet[_M], super().select_related(*fields))
 
 except ImportError:
     pass

--- a/tests/test_managers/test_async_methods.py
+++ b/tests/test_managers/test_async_methods.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_related_manager_async_methods_and_polymorphic_manager():
+    from app.models import Order, Product, User
+
+    user = await User.objects.acreate(username="async_u", phone="100")
+    order = await Order.objects.acreate(user=user)
+
+    product, created = await Product.objects.aget_or_create(name="p", price=1)
+    assert created
+
+    await order.products.aset([product])
+    related = await order.products.aall()
+    assert related == [product]
+
+    await order.products.aset([])
+    await order.products.aadd(product)
+    assert await order.products.aall() == [product]
+
+    order2, created2 = await Order.objects.aget_or_create(user=user)
+    assert order2 == order and not created2
+
+    orders = await Order.objects.prefetch_related("products").aall()
+    assert order in orders


### PR DESCRIPTION
## Summary
- add aset/aadd and typed queryset methods to async managers
- provide async wrappers for polymorphic manager
- expose relation manager type for AManyToManyField
- test async related manager methods and polymorphic manager

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38f7d854883308c74a93b623651bd