### PR TITLE
Improve async M2M typing and user manager defaults

### DIFF
--- a/adjango/descriptors.py
+++ b/adjango/descriptors.py
@@ -1,7 +1,7 @@
 # descriptors.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from django.db.models.fields.related_descriptors import ManyToManyDescriptor
 
@@ -42,6 +42,13 @@ class AManyToManyDescriptor(ManyToManyDescriptor, Generic[_RM]):
         # allows IDEs and type checkers to infer the concrete model type instead
         # of the generic ``_RM`` placeholder.
         class AManyRelatedManager(original_manager_cls, AManager[related_model]):  # type: ignore[type-arg]
+            def all(self) -> "AQuerySet[related_model]":  # type: ignore[override]
+                from adjango.querysets.base import AQuerySet
+
+                # ``ManyRelatedManager`` returns a plain ``QuerySet``.  Casting
+                # to ``AQuerySet`` preserves the async methods and typing.
+                return cast(AQuerySet[related_model], super().all())
+
             async def aall(self) -> list[related_model]:  # type: ignore[valid-type]
                 """Возвращает все связанные объекты."""
                 from asgiref.sync import sync_to_async

--- a/adjango/models/base.py
+++ b/adjango/models/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 
 from django.contrib.auth.models import AbstractUser
 from django.db.models import Model
@@ -44,7 +44,11 @@ class AModel(Model):
 class AAbstractUser(AbstractUser, AModel):
     """Enhanced abstract user model with service integration."""
 
-    objects: AUserManager[Self]  # type: ignore
+    # Provide a default asynchronous manager so that subclasses immediately gain
+    # access to methods like ``acreate_user``.  Without this assignment the
+    # parent ``AbstractUser`` manager (``UserManager``) would be used instead,
+    # which lacks async helpers and caused ``AttributeError`` in tests.
+    objects: ClassVar[AUserManager[Self]] = AUserManager()
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Summary
- ensure AManyToManyField propagates related model type and returns typed manager
- return typed AQuerySet from many-to-many descriptor
- provide default AUserManager for AAbstractUser

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a396c1f8348330b12ad651184bdbb6