### PR TITLE
Improve type hints for async related managers

### DIFF
--- a/adjango/descriptors.py
+++ b/adjango/descriptors.py
@@ -15,6 +15,9 @@ _RM = TypeVar("_RM", bound="Model")
 
 
 class AManyToManyDescriptor(ManyToManyDescriptor, Generic[_RM]):
+    if TYPE_CHECKING:
+        def __get__(self, instance: "Model | None", owner: type | None = None) -> AManager[_RM]: ...
+
     def __init__(self, rel, reverse=False):
         super().__init__(rel, reverse)
         self._related_model = None

--- a/adjango/managers/base.py
+++ b/adjango/managers/base.py
@@ -61,6 +61,9 @@ class AManager(Manager.from_queryset(AQuerySet), Generic[_M]):  # type: ignore
         await self.get_queryset().aadd(data, *args, **kwargs)
 
     # Typed queryset-returning methods to preserve chaining types
+    def all(self) -> AQuerySet[_M]:  # type: ignore[override]
+        return cast(AQuerySet[_M], super().all())
+
     def filter(self, *args: Any, **kwargs: Any) -> AQuerySet[_M]:  # type: ignore[override]
         return cast(AQuerySet[_M], super().filter(*args, **kwargs))
 


### PR DESCRIPTION
## Summary
- ensure AManyToManyDescriptor exposes typed AManager via __get__
- return typed AQuerySet from AManager.all

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39958e0a48330a39ef5cb652ed952