### PR TITLE
Improve typing for many-to-many managers

### DIFF
--- a/adjango/descriptors.py
+++ b/adjango/descriptors.py
@@ -9,14 +9,29 @@ from adjango.managers.base import AManager
 
 if TYPE_CHECKING:
     from django.db.models import Model
+    from adjango.querysets.base import AQuerySet
 
 # Type variable for related model
 _RM = TypeVar("_RM", bound="Model")
 
 
+class AManyRelatedManager(AManager[_RM], Generic[_RM]):
+    """Typed base manager for many-to-many relations.
+
+    This class exists purely for static type checking.  The actual manager
+    returned at runtime will subclass Django's dynamically generated
+    ``ManyRelatedManager`` *and* this base class, giving access to the real
+    implementation while preserving the generic ``_RM`` type information.
+    """
+
+    def all(self) -> "AQuerySet[_RM]": ...  # pragma: no cover - typing only
+
+    async def aall(self) -> list[_RM]: ...  # pragma: no cover - typing only
+
+
 class AManyToManyDescriptor(ManyToManyDescriptor, Generic[_RM]):
     if TYPE_CHECKING:
-        def __get__(self, instance: "Model | None", owner: type | None = None) -> AManager[_RM]: ...
+        def __get__(self, instance: "Model | None", owner: type | None = None) -> AManyRelatedManager[_RM]: ...
 
     def __init__(self, rel, reverse=False):
         super().__init__(rel, reverse)
@@ -44,7 +59,9 @@ class AManyToManyDescriptor(ManyToManyDescriptor, Generic[_RM]):
         # typed ``aall`` method.  Using ``related_model`` in the annotations
         # allows IDEs and type checkers to infer the concrete model type instead
         # of the generic ``_RM`` placeholder.
-        class AManyRelatedManager(original_manager_cls, AManager[related_model]):  # type: ignore[type-arg]
+        class _AManyRelatedManager(
+            original_manager_cls, AManyRelatedManager[related_model]  # type: ignore[type-arg]
+        ):
             def all(self) -> "AQuerySet[related_model]":  # type: ignore[override]
                 from adjango.querysets.base import AQuerySet
 
@@ -58,7 +75,7 @@ class AManyToManyDescriptor(ManyToManyDescriptor, Generic[_RM]):
 
                 return await sync_to_async(list)(self.get_queryset())
 
-        return AManyRelatedManager
+        return _AManyRelatedManager
 
     def __set_name__(self, owner, name):
         """Вызывается когда дескриптор присваивается к атрибуту класса."""

--- a/adjango/fields.py
+++ b/adjango/fields.py
@@ -5,11 +5,10 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from django.db.models import ManyToManyField
 
-from adjango.descriptors import AManyToManyDescriptor
+from adjango.descriptors import AManyToManyDescriptor, AManyRelatedManager
 
 if TYPE_CHECKING:
     from django.db.models import Model
-    from adjango.managers.base import AManager
 
 _RM = TypeVar("_RM", bound="Model")
 
@@ -18,12 +17,14 @@ class AManyToManyField(ManyToManyField, Generic[_RM]):
     if TYPE_CHECKING:
         # When accessing the descriptor on a model instance, the related manager
         # should be aware of the concrete model type it manages.  Declaring the
-        # descriptor as returning ``AManager[_RM]`` allows static type checkers to
-        # properly infer the type of objects returned by methods like ``aall`` or
-        # ``all``.  Without inheriting from ``Generic`` and annotating this
-        # method, usages such as ``await order.products.aall()`` would resolve to
-        # ``list[_RM]`` instead of ``list[Product]``.
-        def __get__(self, instance: "Model | None", owner: type | None = None) -> AManager[_RM]: ...
+        # descriptor as returning ``AManyRelatedManager[_RM]`` allows static type
+        # checkers to properly infer the type of objects returned by methods like
+        # ``aall`` or ``all``.  Without inheriting from ``Generic`` and
+        # annotating this method, usages such as ``await order.products.aall()``
+        # would resolve to ``list[_RM]`` instead of ``list[Product]``.
+        def __get__(
+            self, instance: "Model | None", owner: type | None = None
+        ) -> AManyRelatedManager[_RM]: ...
 
     # ``ManyToManyField`` does not support generics out of the box.  By
     # subclassing ``Generic`` we enable expressions like


### PR DESCRIPTION
## Summary
- add typed `AManyRelatedManager` base for many-to-many relations
- ensure `AManyToManyField` and descriptor return typed manager

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39baf695483308a498893e8ca49ac